### PR TITLE
feature 390: added confirmed company email checking process for compa…

### DIFF
--- a/clients/admin/src/components/AddModalForm.tsx
+++ b/clients/admin/src/components/AddModalForm.tsx
@@ -1,4 +1,5 @@
 /** @format */
+import punycode from 'punycode';
 
 import React, { useReducer } from "react";
 import {
@@ -75,6 +76,7 @@ const AddModalForm: React.FC<Props> = ({
   onAddCompanySupervisors,
 }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const punycode = require('punycode');
 
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
@@ -96,6 +98,7 @@ const AddModalForm: React.FC<Props> = ({
     onAddCompanySupervisors({
       ...state,
       companyId: parseInt(state.companyId),
+      user: {...state.user, email: punycode.toUnicode(state.user.email)},
     });
     handleClose()
   };

--- a/clients/admin/src/hooks/useSupervisorManagement.ts
+++ b/clients/admin/src/hooks/useSupervisorManagement.ts
@@ -114,9 +114,11 @@ const useSupervisorManagement = () => {
         body: JSON.stringify(request),
       });
 
+      const responseData = await response.json();
+
       if (!response.ok) {
-        toast.error(errorMessage)
-        throw new Error(errorMessage);
+        toast.error(responseData.message || errorMessage)
+        throw new Error(responseData.message || errorMessage);
       }
 
       getAllCompanySupervisors(pagination?.number || 0);

--- a/src/main/java/tr/edu/ogu/ceng/service/Exception/UnconfirmedMailAddressException.java
+++ b/src/main/java/tr/edu/ogu/ceng/service/Exception/UnconfirmedMailAddressException.java
@@ -1,0 +1,7 @@
+package tr.edu.ogu.ceng.service.Exception;
+
+public class UnconfirmedMailAddressException extends ServiceException {
+    public UnconfirmedMailAddressException() {
+        super("Supervisor's e-mail address does not match confirmed company's e-mail address!");
+    }
+}

--- a/src/main/java/tr/edu/ogu/ceng/service/RegisterAsCompanySupervisorService.java
+++ b/src/main/java/tr/edu/ogu/ceng/service/RegisterAsCompanySupervisorService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.AllArgsConstructor;
+import tr.edu.ogu.ceng.dto.CompanyDto;
 import tr.edu.ogu.ceng.dto.CompanySupervisorDto;
 import tr.edu.ogu.ceng.dto.UserDto;
 import tr.edu.ogu.ceng.dto.requests.RegisterAsCompanySupervisorRequestDto;
@@ -14,6 +15,7 @@ import tr.edu.ogu.ceng.enums.UserType;
 import tr.edu.ogu.ceng.model.CompanySupervisor;
 import tr.edu.ogu.ceng.model.User;
 import tr.edu.ogu.ceng.service.Exception.PasswordsNotMatchedException;
+import tr.edu.ogu.ceng.service.Exception.UnconfirmedMailAddressException;
 
 @Slf4j
 @Service
@@ -21,6 +23,7 @@ import tr.edu.ogu.ceng.service.Exception.PasswordsNotMatchedException;
 public class RegisterAsCompanySupervisorService {
 
 	private final CompanySupervisorService companySupervisorService;
+	private final CompanyService companyService;
 	private final UserService userService;
 	private final ModelMapper mapper;
 
@@ -28,6 +31,7 @@ public class RegisterAsCompanySupervisorService {
 	public RegisterAsCompanySupervisorResponseDto register(RegisterAsCompanySupervisorRequestDto request) {
 
 		checkIfPasswordsMatchingValidation(request);
+		checkIfSupervisorEmailAddressMatchingConfirmedCompanyEmailAddress(request);
 
 		UserDto userDto = mapper.map(request, UserDto.class);
 		userDto.setUserType(UserType.COMPANYSUPERVISOR);
@@ -58,6 +62,21 @@ public class RegisterAsCompanySupervisorService {
 		}
 		else {
 			log.info("Passwords are matching");
+		}
+	}
+
+	private void checkIfSupervisorEmailAddressMatchingConfirmedCompanyEmailAddress(RegisterAsCompanySupervisorRequestDto request) {
+		UserDto userDto = mapper.map(request, UserDto.class);
+		CompanyDto companyDto = companyService.getCompany(request.getCompany().getId());
+
+		String supervisorMail = userDto.getEmail();
+		String companyMail = companyDto.getEmail();
+
+		String confirmedCompanyEmailAddress = companyMail.substring(companyMail.indexOf("@"));
+
+		if (!supervisorMail.endsWith(confirmedCompanyEmailAddress)) {
+			log.error("Supervisor's e-mail address does not match confirmed company's e-mail address!");
+			throw new UnconfirmedMailAddressException();
 		}
 	}
 


### PR DESCRIPTION
```/api/company-supervisor``` ve ```/public/api/registerascompanysupervisor``` endpointleri üzeriden atılan company supervisor ekleme işlemlerinde onaylı şirket mail adres kontrolü eklendi. Şirket mail adresi ```info@akdenizinşaa.com``` olsun, bu şirkete ait şirket sorumluların da mail adresleri @akdenizinşaa.com şeklinde bitmeli örneğin ```yakub@akdenizinşaa.com``` olmalı, aksi takdirde hem sunucudan hem de UI üzerinden kullanıcıya hata mesajı veriliyor.
<br/>
Hata vermesini beklediğimiz bir senaryo(hata veriyor beklendiği gibi):
<img width="875" alt="Screenshot 2024-04-10 at 22 38 01" src="https://github.com/esogu-ceng/internship-management-system/assets/97192201/fe4565ab-d0fd-4086-ad32-48a575f5ecb1">
<br/>
Çalışması gereken bir senaryo(çalışıyor):
<img width="692" alt="Screenshot 2024-04-10 at 22 42 58" src="https://github.com/esogu-ceng/internship-management-system/assets/97192201/09ba9d7e-660a-4b60-9154-834d7e1958c8">
<br/>

UI üzerinde admin paneli üzerinden şirket sorumlusu ekleme senaryosu(onaylı olmayan email adresi girildiği için hata mesajı veriyor):
![Screenshot 2024-04-10 at 23 37 05](https://github.com/esogu-ceng/internship-management-system/assets/97192201/9de57e09-75a1-4714-9244-527040416429)
<br/>

Seçilen şirkete ait onaylı mail adresi ile mail adresi girince sorunsuz çalışıyor:
![Screenshot 2024-04-11 at 00 04 02](https://github.com/esogu-ceng/internship-management-system/assets/97192201/da902c32-bc20-4bf1-b5ff-e3a8183a2eb3)



